### PR TITLE
Update db url by optional hostname and port

### DIFF
--- a/src/main/java/io/github/btmxh/apartmentapp/DatabaseConnection.java
+++ b/src/main/java/io/github/btmxh/apartmentapp/DatabaseConnection.java
@@ -17,9 +17,17 @@ public class DatabaseConnection
     private DatabaseConnection() {
         try {
             Dotenv dotenv = Dotenv.load();
-            String url = "jdbc:mysql://localhost:3306/apartment";
+            String hostname = dotenv.get("DB_HOSTNAME");
+            String port = dotenv.get("DB_PORT");
             String username = dotenv.get("DB_USERNAME");
             String password = dotenv.get("DB_PASSWORD");
+            if (hostname == null) {
+                hostname = "localhost";
+            }
+            if (port == null) {
+                port = "3306";
+            }
+            String url ="jdbc:mysql://" + hostname + ":" + port + "/apartment";
             connection = DriverManager.getConnection(url, username, password);
             logger.info("Successfully connected to Database!");
         } catch(SQLException e) {


### PR DESCRIPTION
**Thêm phần tùy chọn DB_HOSTNAME và DB_PORT trong file .env:**

- Nếu không xác định DB_HOSTNAME  thì mặc định là localhost
- Nếu không xác định DB_PORT thì mặc định là 3306

**Tuy nhiên khi tôi cho DB_HOSTNAME và DB_PORT là xâu rỗng thì vẫn kết nối được với database apartment**
VD:
DB_HOSTNAME=
DB_PORT=
DB_USERNAME=root
DB_PASSWORD=password




